### PR TITLE
Upgrade to eslint 2.0

### DIFF
--- a/eslint-config.yaml
+++ b/eslint-config.yaml
@@ -1,5 +1,5 @@
 extends:
-  - eslint:recommended
+  - "eslint:recommended"
 
 parser: babel-eslint
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "js-yaml": "^3.4.2"
   },
   "dependencies": {
-    "babel-eslint": "^5.0.0-beta6",
-    "eslint-plugin-react": "^3.16.1"
+    "babel-eslint": "^6.0.4",
+    "eslint-plugin-react": "^5.0.1"
   }
 }


### PR DESCRIPTION
| Closes #9 |
| --- |

Deprecated rules were fixed before this upgrade. We may wish to investigate another way to handle the `babel-eslint` dependency — [airbnb's config](https://github.com/airbnb/javascript) appears to do a nice job without it.
