### PR TITLE
Fix: react-display-name property

### DIFF
--- a/eslint-config.yaml
+++ b/eslint-config.yaml
@@ -1,5 +1,6 @@
 extends:
   - "eslint:recommended"
+  - "plugin:react/recommended"
 
 parser: babel-eslint
 
@@ -13,31 +14,25 @@ env:
   es6: true
 
 ecmaFeatures:
-  jsx: true
   modules: true
 
 rules:
 
   # React/JSX
 
-  react/display-name: [1, { acceptTranspilerName: true }]
-  react/jsx-uses-react: [1]
-  react/wrap-multilines: [1]
-  react/sort-comp: [1] # See defaults at blob/master/docs/rules/sort-comp.md
-  react/jsx-sort-prop-types: [1, { requiredFirst: true, callbacksLast: true }]
-  react/react-in-jsx-scope: [1]
-  react/prop-types: [1]
-  react/no-direct-mutation-state: [2]
-  react/no-did-update-set-state: [1, allow-in-func]
-  react/no-deprecated: [1]
-  react/jsx-uses-vars: [2]
-  react/jsx-equals-spacing: [1, "never"]
-  react/self-closing-comp: [1]
-  react/jsx-pascal-case: [1]
-  react/jsx-no-undef: [2]
-  react/jsx-no-duplicate-props: [2]
-  react/jsx-max-props-per-line: [1, { maximum: 3 }]
   jsx-quotes: [1]
+  react/jsx-equals-spacing: [1, "never"]
+  react/jsx-max-props-per-line: [1, { maximum: 3 }]
+  react/jsx-pascal-case: [1]
+  react/jsx-uses-react: [1]
+  react/no-deprecated: [1]
+  react/no-did-update-set-state: [1, allow-in-func]
+  react/prop-types: [1]
+  react/react-in-jsx-scope: [1]
+  react/self-closing-comp: [1]
+  react/sort-comp: [1] # See defaults at blob/master/docs/rules/sort-comp.md
+  react/sort-prop-types: [1, { callbacksLast: true, requiredFirst: true }]
+  react/wrap-multilines: [1]
 
 
 

--- a/package.json
+++ b/package.json
@@ -32,6 +32,6 @@
   },
   "dependencies": {
     "babel-eslint": "^6.0.4",
-    "eslint-plugin-react": "^5.0.1"
+    "eslint-plugin-react": "^5.1.1"
   }
 }


### PR DESCRIPTION
This fixes the configuration for the `display-name` property, which changed names [in v4](https://github.com/yannickcr/eslint-plugin-react/blob/master/CHANGELOG.md#400---2016-02-19). Since the rule was inverted, we are getting rid of it.

We are also taking the recommended settings for React in this change, which allow us to remove a few rules from our declaration.
